### PR TITLE
Automatically collapse attribution and layercontrol on smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,8 +369,13 @@ function getClubName(d) {
     
 
 // Highlights displays info for the layer under the mouse
+    var selected;
     function highlightFeature(e) {
+        if (selected){
+            resetHighlight(selected);
+        }
         var layer = e.target;
+        selected = layer;
         layer.openTooltip()
         layer.setStyle({
             weight: 4,
@@ -386,7 +391,8 @@ function getClubName(d) {
 // Turns off the highlight
     var geojson; // makes empty variable
     function resetHighlight(e) {
-        geojson.resetStyle(e.target);
+        geojson.resetStyle(selected);
+        delete selected;
         info.update();
     }
  
@@ -402,9 +408,8 @@ function getClubName(d) {
         if (zoomLevel > maxZoom) {
             zoomLevel = maxZoom;
         }
-        console.log(zoomLevel);
         // Zoom to the feature at the calculated zoom level
-        map.fitBounds(bounds, { maxZoom: zoomLevel });
+        map.setView(bounds.getCenter(), zoomLevel);
     }
 
 // Tasks to do to each feature on creation

--- a/index.html
+++ b/index.html
@@ -392,9 +392,19 @@ function getClubName(d) {
  
 // Zooms to feature when clicked
     function zoomToFeature(e) {
-        //map.fitBounds(e.target.getBounds(),{padding: [200,200]});
-        latilong = e.target.getBounds().getCenter();
-        map.setView(latilong, 14);
+        var maxZoom = 14;
+        var bounds = e.target.getBounds(); // Get the bounding box of the feature
+
+        // Determine the appropriate zoom level
+        var zoomLevel = map.getBoundsZoom(bounds);
+
+        // If the calculated zoom level is greater than the maximum allowed zoom level, limit it
+        if (zoomLevel > maxZoom) {
+            zoomLevel = maxZoom;
+        }
+        console.log(zoomLevel);
+        // Zoom to the feature at the calculated zoom level
+        map.fitBounds(bounds, { maxZoom: zoomLevel });
     }
 
 // Tasks to do to each feature on creation

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
         .leaflet-layerstree-header  {/* Layer Tree Headings */ color: #000}        .leaflet-layerstree-header:hover  { color: #f76d22}
         .leaflet-layerstree-children label {/* Layer Tree */ color: #444}         .leaflet-layerstree-children label:hover  { color: #f76d22}
 
-        /* Media query for screens smaller than 768px */
+/* Media query for screens smaller than 768px */
         @media screen and (max-width: 1000px) {
             /* Hide the attribution at smaller screen sizes */
             .leaflet-control-attribution {
@@ -99,17 +99,19 @@
         All_Maps = L.layerGroup([A]);
 
 // Mapbox requirements    
- //   var mapboxAttribution = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, ' + 'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+    //   var mapboxAttribution = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, ' + 'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
  //           mapboxUrl = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
 
 // Background maps    
-	var osm   = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	let greyscale = L.tileLayer('http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+         });
+	let streets  = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         opacity: 0.75
     });
-	//streets  = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution}),
-    //satellite = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/satellite-streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
+    //let satellite = L.tileLayer(mapboxUrl, {maxZoom: 19, minZoom: 4, id: 'satellite-streets-v12', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
 
     const queryUrl = window.location.search;
     const club = new URLSearchParams(queryUrl).get('club');
@@ -132,7 +134,7 @@
 
 
 // Draw the default map    
-	var map = L.map('map', {center: [defaultLat, defaultLng], zoom: defaultZoom, layers: [osm, OW_Maps,HV_Maps,RK_Maps,WR_Maps,PP_Maps]});
+	var map = L.map('map', {center: [defaultLat, defaultLng], zoom: defaultZoom, layers: [streets, OW_Maps,HV_Maps,RK_Maps,WR_Maps,PP_Maps]});
 
 // Club layer group tree
     var layerTree = {    
@@ -182,11 +184,12 @@
 // Creates layer control and which layers to include as options
     var backgroundLayers = { 
         label: "<class = BS /> <span > <b>Basemaps</b> </span>",
-        children: [ { label: "OSM <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: osm},
-                   // { label: "Streets <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: streets},
-                   // { label: "Satellite <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: satellite},
-                ]        
-	    };
+        children: [ { label: "Streets <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: streets},
+                    { label: "Dark <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: greyscale},       
+                   // { label: "Satellite <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: satellite},]        
+
+                ]
+                };
 	// var mapLayers = {
     //     "<class = OW /> <span style='color:#4381de; font-size:16px'> &#9706 </span> <span> OW Maps </span>":OW_Maps,
     //     "<class = HV /> <span style='color:#f79e05; font-size:16px'> &#9706 </span> <span> HV Maps </span>":HV_Maps,
@@ -211,7 +214,7 @@
 	// L.control.layers(null, mapLayers, { position: 'bottomright', collapsed: true }).addTo(map);
     let layerControl = L.control.layers.tree(backgroundLayers, layerTree,{ collapsed: false }).addTo(map);
 
-    // Function to handle resizing and adjusting the layer control
+// Function to handle resizing and adjusting the layer control
     function adjustLayerControl() {
         const screenWidth = window.innerWidth;
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         .leaflet-control-search .search-button:hover {/*Search Button Hover*/ /*background: url('search-icon.png') no-repeat 4px 4px #5c89a788;*/  border-radius: 4px;}
 
         .leaflet-control-layers {/*Layers Control*/ background: rgba(255,255,255,1); box-shadow: 0 0 15px rgba(0,0,0,1);}
-        .leaflet-control-layers-expanded {/*Expanded Layers Control*/ color: #000;	background: #fff; line-height:5px; width:114px;}
+        .leaflet-control-layers-expanded {/*Expanded Layers Control*/ color: #000;	background: #fff; line-height:5px; width:120px;}
         .leaflet-control-layers-separator {/* Layer Separator */ border-top: 2px solid #cacaca;}
         .leaflet-control-layers-selector{ /* Layer Tickbox */ filter:brightness(90%) contrast(150%) hue-rotate(270deg) grayscale(100%);}
         .leaflet-control-layers-selector:hover{ /* Layer Tickbox */ opacity:1;}
@@ -46,6 +46,14 @@
         .leaflet-layerstree-opened, .leaflet-layerstree-closed  {/* Layer Tree */ display: none; color: #f76d22}
         .leaflet-layerstree-header  {/* Layer Tree Headings */ color: #000}        .leaflet-layerstree-header:hover  { color: #f76d22}
         .leaflet-layerstree-children label {/* Layer Tree */ color: #444}         .leaflet-layerstree-children label:hover  { color: #f76d22}
+
+        /* Media query for screens smaller than 768px */
+        @media screen and (max-width: 1000px) {
+            /* Hide the attribution at smaller screen sizes */
+            .leaflet-control-attribution {
+                display: none;
+            }
+        }
 
     </style>
 </head>
@@ -91,13 +99,17 @@
         All_Maps = L.layerGroup([A]);
 
 // Mapbox requirements    
-    var mapboxAttribution = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, ' + 'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-            mapboxUrl = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
+ //   var mapboxAttribution = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, ' + 'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
+ //           mapboxUrl = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
 
 // Background maps    
-	var greyscale   = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 17, minZoom: 4, id: 'mapbox/light-v9', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution}),
-		streets  = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution}),
-        satellite = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/satellite-streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
+	var osm   = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        opacity: 0.75
+    });
+	//streets  = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution}),
+    //satellite = L.tileLayer(mapboxUrl, {maxZoom: 17, minZoom: 4, id: 'mapbox/satellite-streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
 
     const queryUrl = window.location.search;
     const club = new URLSearchParams(queryUrl).get('club');
@@ -120,7 +132,7 @@
 
 
 // Draw the default map    
-	var map = L.map('map', {center: [defaultLat, defaultLng], zoom: defaultZoom, layers: [greyscale, OW_Maps,HV_Maps,RK_Maps,WR_Maps,PP_Maps]});
+	var map = L.map('map', {center: [defaultLat, defaultLng], zoom: defaultZoom, layers: [osm, OW_Maps,HV_Maps,RK_Maps,WR_Maps,PP_Maps]});
 
 // Club layer group tree
     var layerTree = {    
@@ -170,9 +182,10 @@
 // Creates layer control and which layers to include as options
     var backgroundLayers = { 
         label: "<class = BS /> <span > <b>Basemaps</b> </span>",
-        children: [ { label: "Greyscale <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: greyscale},
-                    { label: "Streets <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: streets},
-                    { label: "Satellite <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: satellite},]        
+        children: [ { label: "OSM <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: osm},
+                   // { label: "Streets <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: streets},
+                   // { label: "Satellite <span style='color:#ffffff; font-size:16px'> &#9706 </span>", layer: satellite},
+                ]        
 	    };
 	// var mapLayers = {
     //     "<class = OW /> <span style='color:#4381de; font-size:16px'> &#9706 </span> <span> OW Maps </span>":OW_Maps,
@@ -196,8 +209,26 @@
     //     "<class = AM /> <span style='color:#ffffff; font-size:16px'> &#9706 </span> <span> All Clubs </span>": All_Maps
 	// };
 	// L.control.layers(null, mapLayers, { position: 'bottomright', collapsed: true }).addTo(map);
-    L.control.layers.tree(backgroundLayers, layerTree,{ collapsed: false }).addTo(map);
+    let layerControl = L.control.layers.tree(backgroundLayers, layerTree,{ collapsed: false }).addTo(map);
 
+    // Function to handle resizing and adjusting the layer control
+    function adjustLayerControl() {
+        const screenWidth = window.innerWidth;
+
+        if (screenWidth < 768) {
+            // Collapse the layer control
+            layerControl.collapse();
+        } else {
+            // Expand the layer control
+            layerControl.expand();
+        }
+    }
+
+    // Initially adjust the layer control based on the screen size
+    adjustLayerControl();
+
+    // Listen for window resize events
+    window.addEventListener('resize', adjustLayerControl);
 
 // Add OW logo to corner    
     L.Control.Watermark = L.Control.extend({


### PR DESCRIPTION
This change automatically collapses the layer control when the screen size is less than 768px, and hides the attribution under 1000px as currently on smaller screens they take up too much space.

I also fixed the basemap, and added an opacity of 75% to the tile layer